### PR TITLE
0 6

### DIFF
--- a/lib/netzke/actions.rb
+++ b/lib/netzke/actions.rb
@@ -89,7 +89,7 @@ module Netzke
           case c[:icon]
           when Symbol then c[:icon] = uri_to_icon(c[:icon])
           when String
-            if c[:icon] !~ /\.png/
+            if c[:icon] !~ /^\//
               c[:icon] = uri_to_icon(c[:icon])
             end
           end


### PR DESCRIPTION
Some icons sets use dashes in file names, like for example Fugue icons (http://p.yusukekamiyamane.com/). With such icons I always have to do:

```
   :icon => "ui-check-boxes".to_sym
```

Patch will allow use of strings same way as  Symbols used now:

```
  :icon => "ui-check-boxes"
```

Only for strings without .png extension, i.e. if string is not full file name.
