### PR TITLE
'//' in form_authenticity_token causes unterminated string literal

### DIFF
--- a/lib/netzke/core_ext/string.rb
+++ b/lib/netzke/core_ext/string.rb
@@ -11,12 +11,12 @@ class String
 
   # removes JS-comments (both single- and multi-line) from the string
   def strip_js_comments
-    regexp = /\/\/.*$|(?m:\/\*.*?\*\/)/
-    self.gsub!(regexp, '')
-
-    # also remove empty lines
-    regexp = /^\s*\n/
-    self.gsub!(regexp, '')
+    if defined?(::Rails) && Rails.application.assets.js_compressor
+      compressor = Rails.application.assets.js_compressor
+      compressor.processor.call(nil, self)
+    else
+      self
+    end
   end
 
   # "false" => false, "whatever_else" => true

--- a/test/core_test_app/Gemfile
+++ b/test/core_test_app/Gemfile
@@ -5,6 +5,8 @@ gem 'netzke-persistence'
 
 gem 'sqlite3'
 
+gem 'uglifier'
+gem 'execjs'
 # Use unicorn as the web server
 # gem 'unicorn'
 

--- a/test/core_test_app/Gemfile.lock
+++ b/test/core_test_app/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
     database_cleaner (0.8.0)
     diff-lcs (1.1.3)
     erubis (2.7.0)
+    execjs (1.4.0)
+      multi_json (~> 1.0)
     ffi (1.1.5)
     gherkin (2.11.2)
       json (>= 1.4.6)
@@ -128,6 +130,9 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.33)
+    uglifier (1.3.0)
+      execjs (>= 0.3.0)
+      multi_json (~> 1.0, >= 1.0.2)
     xpath (0.1.4)
       nokogiri (~> 1.3)
 
@@ -139,9 +144,11 @@ DEPENDENCIES
   cucumber
   cucumber-rails
   database_cleaner
+  execjs
   launchy
   netzke-persistence
   rails (= 3.2.3)
   rspec-rails
   spork
   sqlite3
+  uglifier

--- a/test/core_test_app/config/application.rb
+++ b/test/core_test_app/config/application.rb
@@ -44,5 +44,8 @@ module RailsApp
 
     # Enable the asset pipeline
     config.assets.enabled = true
+    
+    config.assets.compress = true
+    config.assets.js_compressor = :uglifier
   end
 end

--- a/test/core_test_app/spec/core_ext_spec.rb
+++ b/test/core_test_app/spec/core_ext_spec.rb
@@ -16,4 +16,12 @@ describe "Core extensions" do
   it "should properly do deep_map" do
     {a: [1,2,{b:3},{c:[4,5]}], d: 6}.deep_map{|el| el.is_a?(Hash) ? el.merge(e:7) : el + 10}.should == { a: [11,12,{e:7, b:3},{e:7, c:[14,15]}], d: 6}
   end
+
+  it "should strip js comments" do
+    "var test;//commment".strip_js_comments.should == "var test;"
+  end
+
+  it "should not strip // in strings" do
+    'var someVar = "abc//def";'.strip_js_comments.should == 'var someVar="abc//def";'
+  end
 end


### PR DESCRIPTION
Hi,

today I ran into a strange behaviour of netzke. Whenever the form_authenticity_token contains two slashes ('//') the site won't load because of a JavaScript error "SyntaxError: unterminated string literal".

Here's an example:

``` ruby
form_authenticity_token = "Mns6XnkQVAVsBnUi8hoELD5y1jhMnLuSa+z/fax//3s="
```

ends up with the following netzke/ext.js

``` javascript
Ext.Ajax.extraParams = {authenticity_token: 'Mns6XnkQVAVsBnUi8hoELD5y1jhMnLuSa+z/fax
...
```

It only happens in production, so gues it has something to do with removing comments in JS files.
A 'correct' version of netzke/ext.js looks like the following in my case (without a comment at the end of the line):

``` javascript
Ext.Ajax.extraParams = {authenticity_token: 's9ajCtifhGq9qR4WopH7r0QCCnydQxRPd2tLO8HeVCE='}; 
Ext.ns('Netzke');
```

Here are my gems:
https://gist.github.com/3235417
I use ruby 1.9.3

EDIT:
I've just found out that most likely String#strip_js_comments causes the problem.
I guess Uglifier would do the trick, but that would also introduce another dependency :(
https://github.com/lautis/uglifier

Maybe something like this could solve it:

``` ruby
begin
  # Use uglifier here
rescue LoadError
  # No Uglifier => fallback to strip_js_comments (or don't do anything)
end
```
