### PR TITLE
Netzke in a Hobo based Rails application

### DIFF
--- a/lib/netzke-core.rb
+++ b/lib/netzke-core.rb
@@ -1,3 +1,21 @@
+# Hobo specific
+#
+# Hobo includes a bunch of extensions and patches to various Rails and Ruby
+# classes including ActiveRecord, Array and Hash in it's `hobo_support` gem.
+#
+# To let both libraries co-exist nicely let's make sure that the Hobo
+# extensions and patches to Rails and Ruby classes get loaded before
+# requiring Netzke's extensions and patches.
+#
+# Important: To make this work Hobo must be listed before the Netzke gems
+#            in the Gemfile!
+#
+# This has been tested with Hobo 2.0.0.pre7 and Rails 3.2.9.
+#
+if defined? HoboSupport
+  require 'hobo_support'
+end
+
 require 'netzke/core'
 require 'netzke/base'
 


### PR DESCRIPTION
Updated `lib/netzke-core` to require the `hobo_support` gem early so Netzke can be used in a Rails application that depends on Hobo http://hobocentral.net

Hobo includes a bunch of extensions and patches to various Rails and Ruby classes including ActiveRecord, Array and Hash in it's `hobo_support` gem.

To let both libraries co-exist nicely let's make sure that the Hobo extensions and patches to Rails and Ruby classes get loaded before requiring Netzke's extensions and patches.

This update should have not influence on plain Rails applications because the `require` statement is guarded by `if defined? HoboSupport`.
