### PR TITLE
Extend rails 3.2.11 workaround to versions of rails > 3.2.11

### DIFF
--- a/app/controllers/netzke_controller.rb
+++ b/app/controllers/netzke_controller.rb
@@ -19,7 +19,7 @@ class NetzkeController < ApplicationController
       result+=']'
     else # this is a single request
       # Work around Rails 3.2.11 issues
-      if ::Rails.version == '3.2.11'
+      if ::Rails.version >= '3.2.11'
         result=invoke_endpoint params[:act], params[:method].underscore, params[:data].try(:first), params[:tid]
       else
         result=invoke_endpoint params[:act], params[:method].underscore, params[:data].first, params[:tid]


### PR DESCRIPTION
It seems that whatever required a workaround for Rails 3.2.11, still requires it after version bump to 3.2.12. I fixed that
