### PR TITLE
Line break error of netzkeFeedback when multiple error raised.

### DIFF
--- a/javascripts/ext.js
+++ b/javascripts/ext.js
@@ -492,7 +492,7 @@ Ext.define(null, {
     var feedback = "";
 
     Ext.each(msg, function(m){
-      feedback += m.msg || m + "<br/>"
+      feedback += (m.msg || m) + "<br/>"
     });
 
     if (feedback != "") {


### PR DESCRIPTION
Operator precedence of '+' is higher than '||'. If parentheses is missing, all the error messages are shown in one line. 
