### PR TITLE
Also check for icons in the assets.

### DIFF
--- a/lib/netzke/core/railz/engine.rb
+++ b/lib/netzke/core/railz/engine.rb
@@ -9,7 +9,17 @@ module Netzke
       # before loading initializers
       config.before_initialize do |app|
         Netzke::Core.ext_path = Rails.root.join('public', Netzke::Core.ext_uri[1..-1])
-        Netzke::Core.with_icons = File.exists?("#{::Rails.root}/public#{Netzke::Core.icons_uri}") if Netzke::Core.with_icons.nil?
+        if Netzke::Core.with_icons.nil?
+          icon_folder_exists = File.exists?("#{::Rails.root}/public#{Netzke::Core.icons_uri}")
+          unless icon_folder_exists && Netzke::Core.icons_uri =~ /^assets/
+            assets_icons_path = File.join("assets", "images", Netzke::Core.icons_uri[7..-1])
+            icon_folder_exists =
+              File.exists?(File.join(Rails.root, assets_icons_path)) ||
+              File.exists?(File.join(Rails.root, "lib", assets_icons_path)) ||
+              File.exists?(File.join(Rails.root, "vendor", assets_icons_path))
+          end
+          Netzke::Core.with_icons = icon_folder_exists
+        end
       end
     end
   end


### PR DESCRIPTION
Netzke now uses `assets/icons` as the default path
to find the icons, so we need to look for the icons
in the asset-folders. Since the icons are supplied
by a vendor, I place those generally in `vendor/assets`
so for completeness check all asset paths.

This will still fail if the icons are bundled in a
asset gem.

I can still clean up the code a bit, and add tests, but I needed this code myself when I moved my 
icons from `public/images/icons` to `vendors/assets/images/icons`. All the action-columns worked, but the
buttons in toolbars suddenly lost their icons.

This change fixes that.
