### PR TITLE
boboism patch multipart upload session string keys error

### DIFF
--- a/lib/netzke/core/railz/controller_extensions.rb
+++ b/lib/netzke/core/railz/controller_extensions.rb
@@ -83,7 +83,7 @@ module Netzke
 
       # Old-way action used at multi-part form submission (endpointUrl)
       def dispatcher
-        endpoint_dispatch(params[:address].deep_symbolize_keys)
+        endpoint_dispatch(params[:address])
       end
 
     protected
@@ -121,7 +121,8 @@ module Netzke
       # E.g.: some_grid__post_grid_data.
       def endpoint_dispatch(endpoint_path)
         component_name, *sub_components = endpoint_path.split('__')
-        component_instance = Netzke::Base.instance_by_config(session[:netzke_components][component_name.to_sym])
+        components_in_session = session[:netzke_components].try(:deep_symbolize_keys)
+        component_instance = Netzke::Base.instance_by_config(components_in_session[component_name.to_sym])
 
         # We can't do this here; this method is only used for classic form submission, and the response from the server
         # should be the (default) "text/html"

--- a/lib/netzke/core/railz/controller_extensions.rb
+++ b/lib/netzke/core/railz/controller_extensions.rb
@@ -1,3 +1,4 @@
+require 'active_support/core_ext'
 module Netzke
   module Railz
     # Before each request, Netzke::Base.controller and Netzke::Base.session are set, to be accessible from components.

--- a/lib/netzke/core/railz/controller_extensions.rb
+++ b/lib/netzke/core/railz/controller_extensions.rb
@@ -82,7 +82,7 @@ module Netzke
 
       # Old-way action used at multi-part form submission (endpointUrl)
       def dispatcher
-        endpoint_dispatch(params[:address])
+        endpoint_dispatch(params[:address].deep_symbolize_keys)
       end
 
     protected


### PR DESCRIPTION
NoMethodError - undefined method `[]' for nil:NilClass:
  netzke-core (0.12.2) lib/netzke/base.rb:88:in `instance_by_config'
  netzke-core (0.12.2) lib/netzke/core/railz/controller_extensions.rb:123:in `endpoint_dispatch'
  netzke-core (0.12.2) lib/netzke/core/railz/controller_extensions.rb:85:in `dispatcher'
  actionpack (4.2.3) lib/action_controller/metal/implicit_render.rb:4:in `send_action'
  actionpack (4.2.3) lib/abstract_controller/base.rb:198:in `process_action'
  actionpack (4.2.3) lib/action_controller/metal/rendering.rb:10:in `process_action'
  actionpack (4.2.3) lib/abstract_controller/callbacks.rb:20:in `block in process_action'
  activesupport (4.2.3) lib/active_support/callbacks.rb:115:in `call'
  activesupport (4.2.3) lib/active_support/callbacks.rb:553:in `block (2 levels) in compile'
  activesupport (4.2.3) lib/active_support/callbacks.rb:503:in `call'
  activesupport (4.2.3) lib/active_support/callbacks.rb:88:in `run_callbacks'
  actionpack (4.2.3) lib/abstract_controller/callbacks.rb:19:in `process_action'