### PR TITLE
default_routes config

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  netzke unless Rails.application.routes.named_routes.routes[:netzke]
+  if Netzke::Core.default_routes
+    netzke unless Rails.application.routes.named_routes.routes[:netzke]
+  end
 end

--- a/lib/netzke/core.rb
+++ b/lib/netzke/core.rb
@@ -14,6 +14,7 @@ module Netzke
   # The following configuration options are available:
   # * ext_path - absolute path to your Ext code root
   # * icons_uri - relative URI to the icons
+  # * default_routes - either to include netzke routes by default into Rails app
   module Core
     autoload :VERSION, 'netzke/core/version'
     autoload :DslConfigBase, 'netzke/core/dsl_config_base'
@@ -59,6 +60,9 @@ module Netzke
     @@client_notification_delay = 2000
 
     mattr_accessor :with_icons
+
+    mattr_accessor :default_routes
+    @@default_routes = true
 
     def self.setup
       yield self


### PR DESCRIPTION
i was trying to use netzke inside my isolated engine. i have this in my main app routes.rb

```
Rails.application.routes.draw do
  mount Admin::Engine, at: '/admin'
end
```

and in my engine's routes.rb

```
Admin::Engine.routes.draw do
  netzke
end
```

so i ended up with double netzke routes like this

```
           Prefix Verb     URI Pattern                         Controller#Action
            admin          /admin                              Admin::Engine
netzke_components GET      /netzke/components/:class(.:format) netzke/testing#components
     netzke_specs GET      /netzke/specs/*name(.:format)       netzke/testing#specs
           netzke GET      /netzke(.:format)                   netzke#index
       netzke_ext GET      /netzke/ext(.:format)               netzke#ext
    netzke_direct GET|POST /netzke/direct(.:format)            netzke#direct
netzke_dispatcher GET|POST /netzke/dispatcher(.:format)        netzke#dispatcher

Routes for Admin::Engine:
           netzke GET      /netzke(.:format)            admin/netzke#index
       netzke_ext GET      /netzke/ext(.:format)        admin/netzke#ext
    netzke_direct GET|POST /netzke/direct(.:format)     admin/netzke#direct
netzke_dispatcher GET|POST /netzke/dispatcher(.:format) admin/netzke#dispatcher
```

couldn't find any way to avoid it, so i added new config variable to be able to disable default routes