### PR TITLE
Update controller_extensions.rb

### DIFF
--- a/lib/netzke/core/railz/controller_extensions.rb
+++ b/lib/netzke/core/railz/controller_extensions.rb
@@ -40,7 +40,11 @@ module Netzke
       extend ActiveSupport::Concern
 
       included do
-        send(:before_filter, :set_controller_and_session)
+        if Rails::VERSION::MAJOR > 4
+          send(:before_action, :set_controller_and_session)
+        else
+          send(:before_filter, :set_controller_and_session)
+        end
       end
 
       module ClassMethods


### PR DESCRIPTION
remove deprecation warning for rails 5